### PR TITLE
url encode authentication elements to api query

### DIFF
--- a/husqvarna_automower/__init__.py
+++ b/husqvarna_automower/__init__.py
@@ -2,6 +2,7 @@
 import time
 import logging
 import aiohttp
+from urllib.parse import urlencode, quote_plus
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -12,6 +13,7 @@ AUTH_HEADERS = {'Content-Type': 'application/x-www-form-urlencoded',
 
 MOWER_API_BASE_URL = 'https://api.amc.husqvarna.dev/v1/mowers/'
 
+
 class GetAccessToken:
     """Class to communicate with the Authentication API."""
 
@@ -19,8 +21,9 @@ class GetAccessToken:
         """Initialize the Auth-API and store the auth so we can make requests."""
         self.username = username
         self.password = password
-        self.api_key= api_key
-        self.auth_data= 'client_id={0}&grant_type=password&username={1}&password={2}'.format(self.api_key,self.username,self.password)
+        self.api_key = api_key
+        self.auth_data = 'client_id={0}&grant_type=password&username={1}&password={2}'.format(urlencode(
+            self.api_key, quote_via=quote_plus), urlencode(self.username, quote_via=quote_plus), urlencode(self.password, quote_via=quote_plus))
 
     async def async_get_access_token(self):
         """Return the token."""

--- a/husqvarna_automower/__init__.py
+++ b/husqvarna_automower/__init__.py
@@ -9,7 +9,7 @@ _LOGGER = logging.getLogger(__name__)
 
 AUTH_API_URL = 'https://api.authentication.husqvarnagroup.dev/v1/oauth2/token'
 AUTH_HEADERS = {'Content-Type': 'application/x-www-form-urlencoded',
-                    'Accept': 'application/json'}
+                'Accept': 'application/json'}
 
 MOWER_API_BASE_URL = 'https://api.amc.husqvarna.dev/v1/mowers/'
 
@@ -36,19 +36,20 @@ class GetAccessToken:
         _LOGGER.debug(f"resp.status: {resp.status}")
         return result
 
+
 class GetMowerData:
     """Class to communicate with the Automower Connect API."""
 
     def __init__(self, api_key, access_token, provider, token_type):
         """Initialize the Communication API to get data."""
-        self.api_key= api_key
+        self.api_key = api_key
         self.access_token = access_token
         self.provider = provider
         self.token_type = token_type
-        self.mower_headers = {'Authorization': '{0} {1}'.format(self.token_type,self.access_token),
-                        'Authorization-Provider': '{0}'.format(self.provider),
-                        'Content-Type': 'application/vnd.api+json',
-                        'X-Api-Key': '{0}'.format(self.api_key)}
+        self.mower_headers = {'Authorization': '{0} {1}'.format(self.token_type, self.access_token),
+                              'Authorization-Provider': '{0}'.format(self.provider),
+                              'Content-Type': 'application/vnd.api+json',
+                              'X-Api-Key': '{0}'.format(self.api_key)}
 
     async def async_mower_state(self):
         """Return the mowers data as a list of mowers."""
@@ -59,20 +60,22 @@ class GetMowerData:
         _LOGGER.debug(f"resp.status: {resp.status}")
         return result
 
+
 class Return:
     """Class to send commands to the Automower Connect API."""
+
     def __init__(self, api_key, access_token, provider, token_type, mower_id, payload):
         """Initialize the API and store the auth so we can make requests."""
-        self.api_key= api_key
+        self.api_key = api_key
         self.access_token = access_token
         self.provider = provider
         self.token_type = token_type
         self.mower_id = mower_id
-        self.mower_headers = {'Authorization': '{0} {1}'.format(self.token_type,self.access_token),
-                        'Authorization-Provider': '{0}'.format(self.provider),
-                        'Content-Type': 'application/vnd.api+json',
-                        'accept': '*/*',
-                        'X-Api-Key': '{0}'.format(self.api_key)}
+        self.mower_headers = {'Authorization': '{0} {1}'.format(self.token_type, self.access_token),
+                              'Authorization-Provider': '{0}'.format(self.provider),
+                              'Content-Type': 'application/vnd.api+json',
+                              'accept': '*/*',
+                              'X-Api-Key': '{0}'.format(self.api_key)}
         self.mower_action_url = f"{MOWER_API_BASE_URL}{self.mower_id}/actions"
         self.payload = payload
 


### PR DESCRIPTION
allow characters that would otherwise be interpreted as url syntax to be used in the authentication strings.